### PR TITLE
PR #2 - Type Declarations for Static Assets

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,29 @@
+declare module '*.gif' {
+  const content: string;
+  export default content;
+}
+
+declare module '*.png' {
+  const content: string;
+  export default content;
+}
+
+declare module '*.svg' {
+  const content: string;
+  export default content;
+}
+
+declare module '*.jpg' {
+  const content: string;
+  export default content;
+}
+
+declare module '*.jpeg' {
+  const content: string;
+  export default content;
+}
+
+declare module '*.css' {
+  const classes: { [key: string]: string };
+  export default classes;
+} 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,7 +35,8 @@
     "next-env.d.ts",
     "**/*.ts",
     "**/*.tsx",
-    ".next/types/**/*.ts"
+    ".next/types/**/*.ts",
+    "src/types.d.ts"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
This PR adds custom type declarations for importing static assets such as images (.gif, .png, .svg, .jpg, .jpeg) and CSS modules (.css) into our TypeScript project. These declarations are defined in src/types.d.ts and allow TypeScript to recognize and correctly type these asset imports without throwing module errors.